### PR TITLE
update doctest to 2.4.11

### DIFF
--- a/ports/doctest/CONTROL
+++ b/ports/doctest/CONTROL
@@ -1,4 +1,4 @@
 Source: doctest
-Version: 2.3.8
-Homepage: https://github.com/onqtam/doctest
+Version: 2.4.11
+Homepage: https://github.com/doctest/doctest
 Description: The fastest feature-rich C++ single-header testing framework for unit tests and TDD

--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO KomodoPlatform/doctest
-    REF d5aa2bfb8f00b6260296a754af3a3a98d93f7b67 #version 2.3.8
-    SHA512 2a3c66a057f810d285a6c0b09c3b2674cd3e05ffd6703fc66e799309db0ce1c055c999c90266b153ffdf3805b0e227194e2ec015a5f26117560053c1088b1b08
+    REPO doctest/doctest
+    REF ae7a13539fb71f270b87eb2e874fbac80bc8dda2 #version 2.4.11
+    SHA512 4158ee38db394bb8a8359b71bbb7c3d3dd2721c765682b92b75bf1e3865283d24a47cb1b14b9faecbbf83712075e9ecfba13df869c1a6922e5ea7c5a4a6f4e3d
     HEAD_REF master
 )
 


### PR DESCRIPTION
old version does not compile on ubuntu 22.04